### PR TITLE
Prune unused includes from distance headers

### DIFF
--- a/inshape3dcore/distance/distance.h
+++ b/inshape3dcore/distance/distance.h
@@ -29,9 +29,6 @@
 //===================================================
 //					INCLUDES
 //===================================================
-#include <iostream>
-#include <vector>
-#include <limits>
 #include <vector3.h>
 
 namespace i3d {

--- a/inshape3dcore/distance/distanceconvexconvexgjk.h
+++ b/inshape3dcore/distance/distanceconvexconvexgjk.h
@@ -27,7 +27,6 @@
 #include <distance.h>
 #include <convexshape.h>
 #include <transform.h>
-#include <vector>
 
 namespace i3d {
 

--- a/inshape3dcore/distance/distancefunctiongrid.h
+++ b/inshape3dcore/distance/distancefunctiongrid.h
@@ -29,9 +29,6 @@
 //===================================================
 //					INCLUDES
 //===================================================
-#include <iostream>
-#include <vector>
-#include <limits>
 #include <vector3.h>
 #include <unstructuredgrid.h>
 #include <geom_config.hpp>

--- a/inshape3dcore/distance/distancelineline.h
+++ b/inshape3dcore/distance/distancelineline.h
@@ -29,9 +29,6 @@
 //===================================================
 //					INCLUDES
 //===================================================
-#include <iostream>
-#include <vector>
-#include <limits>
 #include <vector3.h>
 #include <line3.h>
 

--- a/inshape3dcore/distance/distancelinerec.h
+++ b/inshape3dcore/distance/distancelinerec.h
@@ -29,9 +29,6 @@
 //===================================================
 //					INCLUDES
 //===================================================
-#include <iostream>
-#include <vector>
-#include <limits>
 #include <vector3.h>
 #include <rectangle3.h>
 #include <line3.h>

--- a/inshape3dcore/distance/distancelineseg.h
+++ b/inshape3dcore/distance/distancelineseg.h
@@ -29,9 +29,6 @@
 //===================================================
 //					INCLUDES
 //===================================================
-#include <iostream>
-#include <vector>
-#include <limits>
 #include <vector3.h>
 #include <rectangle3.h>
 #include <segment3.h>

--- a/inshape3dcore/distance/distanceobb3plane.h
+++ b/inshape3dcore/distance/distanceobb3plane.h
@@ -29,9 +29,6 @@
 //===================================================
 //					INCLUDES
 //===================================================
-#include <iostream>
-#include <vector>
-#include <limits>
 #include <vector3.h>
 #include <segment3.h>
 #include <rigidbody.h>

--- a/inshape3dcore/distance/distancepointcylinder.h
+++ b/inshape3dcore/distance/distancepointcylinder.h
@@ -29,9 +29,6 @@
 //===================================================
 //					INCLUDES
 //===================================================
-#include <iostream>
-#include <vector>
-#include <limits>
 #include <vector3.h>
 #include <cylinder.h>
 #include <line3.h>

--- a/inshape3dcore/distance/distancepointpline.h
+++ b/inshape3dcore/distance/distancepointpline.h
@@ -29,9 +29,6 @@
 //===================================================
 //					INCLUDES
 //===================================================
-#include <iostream>
-#include <vector>
-#include <limits>
 #include <vector3.h>
 #include <segment3.h>
 #include <line3.h>

--- a/inshape3dcore/distance/distancepointrec.h
+++ b/inshape3dcore/distance/distancepointrec.h
@@ -29,9 +29,6 @@
 //===================================================
 //					INCLUDES
 //===================================================
-#include <iostream>
-#include <vector>
-#include <limits>
 #include <vector3.h>
 #include <rectangle3.h>
 #include <line3.h>

--- a/inshape3dcore/distance/distancepointseg.h
+++ b/inshape3dcore/distance/distancepointseg.h
@@ -29,9 +29,6 @@
 //===================================================
 //					INCLUDES
 //===================================================
-#include <iostream>
-#include <vector>
-#include <limits>
 #include <vector3.h>
 #include <segment3.h>
 #include <line3.h>

--- a/inshape3dcore/distance/distancesegrec.h
+++ b/inshape3dcore/distance/distancesegrec.h
@@ -29,9 +29,6 @@
 //===================================================
 //					INCLUDES
 //===================================================
-#include <iostream>
-#include <vector>
-#include <limits>
 #include <vector3.h>
 #include <segment3.h>
 #include <rectangle3.h>

--- a/inshape3dcore/distance/distancesegseg.h
+++ b/inshape3dcore/distance/distancesegseg.h
@@ -29,9 +29,6 @@
 //===================================================
 //					INCLUDES
 //===================================================
-#include <iostream>
-#include <vector>
-#include <limits>
 #include <vector3.h>
 #include <segment3.h>
 #include <distance.h>

--- a/inshape3dcore/distance/distancetriangletriangle.h
+++ b/inshape3dcore/distance/distancetriangletriangle.h
@@ -25,9 +25,6 @@
 //                     INCLUDES
 //===================================================
 #include <distance.h>
-#include <iostream>
-#include <vector>
-#include <limits>
 #include <triangle3.h>
 
 namespace i3d {


### PR DESCRIPTION
## Summary
- remove unused `<iostream>`, `<vector>`, and `<limits>` includes from the distance core and algorithm headers so they only rely on the project-specific dependencies

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DFC_BUILD_ID=generic-linux-gcc-release
- cmake --build build --target all -j *(fails: missing `<cstring>` include in math/matrix4x4.cpp, pre-existing)*

------
https://chatgpt.com/codex/tasks/task_e_68dd019f7490832098dd02d4c88f2dac